### PR TITLE
Contest: rename `public` to `publicAccessible`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,7 +63,7 @@ dependencies {
 }
 
 group = "com.github.contestsubmission.backend"
-version = "3.3.2"
+version = "3.4.0"
 
 buildInfo {
 	this.gitInfoMode = BuildInfoExtension.MODE_ERROR

--- a/src/main/kotlin/com/github/contestsubmission/backend/feature/contest/Contest.kt
+++ b/src/main/kotlin/com/github/contestsubmission/backend/feature/contest/Contest.kt
@@ -22,7 +22,7 @@ class Contest(
 	@JoinColumn(nullable = false)
 	var organizer: Person? = Person(),
 	var description: String? = null,
-	var public: Boolean = false,
+	var publicAccessible: Boolean = false,
 	var publicGrading: Boolean = false,
 	override var deadline: LocalDateTime = LocalDateTime.now().plusDays(7),
 	var maxTeamSize: Int = 1,

--- a/src/main/kotlin/com/github/contestsubmission/backend/feature/contest/ContestRepository.kt
+++ b/src/main/kotlin/com/github/contestsubmission/backend/feature/contest/ContestRepository.kt
@@ -12,10 +12,11 @@ import java.util.*
 class ContestRepository : CRUDRepository<Contest, UUID>(Contest::class) {
 
 	fun search(term: String): MutableList<Contest>? =
-		entityManager.createQuery("""
+		entityManager.createQuery(
+			"""
 			SELECT c FROM Contest c WHERE
 				(lower(c.name) LIKE lower(:term) OR lower(c.description) LIKE lower(:term))
-				AND c.public
+				AND c.publicAccessible
 		""".trimIndent(), Contest::class.java)
 			.setParameter("term", "%$term%")
 			.resultList
@@ -71,11 +72,11 @@ class ContestRepository : CRUDRepository<Contest, UUID>(Contest::class) {
 				FROM Contest c
 				LEFT JOIN c.teams t
 				LEFT JOIN FETCH t.members m
-				WHERE c.id = :contestId AND (c.organizer = :caller OR m = :caller)
+				WHERE c.id = :contestId AND (c.organizer.id = :callerId OR m.id = :callerId)
 			""".trimIndent(),
 			PersonalContestDTO::class.java
 		)
-			.setParameter("caller", caller)
+			.setParameter("callerId", caller.id)
 			.setParameter("contestId", contestId)
 			.resultList
 			.firstOrNull()

--- a/src/main/kotlin/com/github/contestsubmission/backend/feature/contest/dto/ContestCreateDTO.kt
+++ b/src/main/kotlin/com/github/contestsubmission/backend/feature/contest/dto/ContestCreateDTO.kt
@@ -10,7 +10,7 @@ data class ContestCreateDTO(
 	@field:NotBlank
 	@field:Schema(example = "My Contest")
 	val name: String,
-	val description: String? = null,
+	val description: String?,
 	@field:Future
 	@field:Schema(example = "2025-05-10T00:00:00")
 	val deadline: LocalDateTime,
@@ -18,15 +18,15 @@ data class ContestCreateDTO(
 	@field:Max(50)
 	@field:Schema(example = "5")
 	val maxTeamSize: Int,
-	val public: Boolean = false,
-	val publicGrading: Boolean = false
+	val publicAccessible: Boolean,
+	val publicGrading: Boolean
 ) : ToEntityDTO<Contest> {
 	override fun toEntity() = Contest(
 		name = name,
 		description = description,
 		deadline = deadline,
 		maxTeamSize = maxTeamSize,
-		public = public,
+		publicAccessible = publicAccessible,
 		publicGrading = publicGrading
 	)
 }

--- a/src/main/resources/db/migration/V3.4.0__contest-public-rename.sql
+++ b/src/main/resources/db/migration/V3.4.0__contest-public-rename.sql
@@ -1,0 +1,2 @@
+ALTER TABLE contest
+	RENAME COLUMN public TO publicAccessible;


### PR DESCRIPTION
Context: the identifier `public` is invalid in TypeScript. As such, the backing field is called `_public`. This creates annoying problems in the client and, albeit manually fixable, this is just hacky at best